### PR TITLE
feat: switch from HTTPoison to Mint

### DIFF
--- a/lib/server_sent_event_stage.ex
+++ b/lib/server_sent_event_stage.ex
@@ -10,6 +10,7 @@ defmodule ServerSentEventStage do
   use GenStage
   require Logger
   alias ServerSentEventStage.Event
+  alias Mint.HTTP
 
   # Client functions
   @doc """
@@ -37,7 +38,7 @@ defmodule ServerSentEventStage do
   end
 
   # Server functions
-  defstruct [:url, :headers, :id, buffer: "", state: :not_connected]
+  defstruct [:url, :headers, :conn, :ref, buffer: "", redirecting?: false]
 
   @doc false
   def init(args) do
@@ -52,42 +53,102 @@ defmodule ServerSentEventStage do
   @doc false
   def handle_info(:connect, state) do
     url = compute_url(state)
-    {:ok, id} = connect_to_url(url, state.headers)
-    {:noreply, [], %{state | id: id}}
+    state = do_connect(url, state)
+    {:noreply, [], state}
   end
 
-  def handle_info(%HTTPoison.AsyncStatus{id: id, code: code}, %{id: id} = state) do
-    state = %{state | state: :connected}
+  def handle_info(message, %{conn: conn} = state) when conn != nil do
+    case HTTP.stream(state.conn, message) do
+      {:ok, conn, responses} ->
+        state = %{state | conn: conn}
+        {state, events} = Enum.reduce_while(responses, {state, []}, &handle_mint_response/2)
 
-    state =
-      if code == 200 do
-        Logger.debug(fn -> "#{__MODULE__} connected" end)
-        state
-      else
-        Logger.warn(fn -> "#{__MODULE__} unexpected status: #{code}" end)
-        do_refresh(state)
-      end
+        {:noreply, events, state}
+
+      {:error, conn, error, responses} ->
+        state = %{state | conn: conn}
+        ref = state.ref
+        {state, events} = Enum.reduce_while(responses, {state, []}, &handle_mint_response/2)
+        {_, {state, events}} = handle_mint_response({:error, ref, error}, {state, events})
+
+        {:noreply, events, state}
+
+      :unknown ->
+        handle_unknown_info(message, state)
+    end
+  end
+
+  def handle_info(message, state) do
+    handle_unknown_info(message, state)
+  end
+
+  def handle_unknown_info({data_tag, _, _}, state) when data_tag in [:ssl, :tcp] do
+    # The can occur after we've re-connected: drop them on the floor
+    {:noreply, [], state}
+  end
+
+  def handle_unknown_info({closed_tag, _}, state) when closed_tag in [:ssl_closed, :tcp_closed] do
+    # These can occur after we've re-connected: drop them on the floor.
+    {:noreply, [], state}
+  end
+
+  def handle_unknown_info(message, state) do
+    # ignore data received unexpectedly
+    Logger.warn(fn ->
+      "#{__MODULE__} unexpected message: #{inspect(message)}\nState: #{inspect(state)}"
+    end)
 
     {:noreply, [], state}
   end
 
-  def handle_info(%HTTPoison.AsyncHeaders{id: id}, %{id: id} = state) do
-    {:noreply, [], state}
+  defp handle_mint_response({:status, ref, 200}, {%{ref: ref}, _events} = acc) do
+    Logger.debug(fn -> "#{__MODULE__} connected" end)
+    {:cont, acc}
   end
 
-  def handle_info(
-        %HTTPoison.AsyncChunk{id: id, chunk: chunk},
-        %{id: id, state: :connected} = state
-      ) do
+  defp handle_mint_response({:status, ref, redirect_code}, {%{ref: ref} = state, events})
+       when redirect_code in [301, 302, 307] do
+    Logger.debug(fn -> "#{__MODULE__} connected, received redirect #{redirect_code}" end)
+    state = %{state | redirecting?: true}
+    {:cont, {state, events}}
+  end
+
+  defp handle_mint_response({:status, ref, code}, {%{ref: ref} = state, events}) do
+    Logger.warn(fn -> "#{__MODULE__} unexpected status: #{code}" end)
+    state = do_refresh(state)
+    {:halt, {state, events}}
+  end
+
+  defp handle_mint_response(
+         {:headers, ref, _headers},
+         {%{ref: ref, redirecting?: false}, _events} = acc
+       ) do
+    {:cont, acc}
+  end
+
+  defp handle_mint_response(
+         {:headers, ref, headers},
+         {%{ref: ref, redirecting?: true} = state, events}
+       ) do
+    {"location", new_location} =
+      Enum.find(headers, fn {header, _value} -> header == "location" end)
+
+    state = reset_state(state)
+    state = do_connect(new_location, state)
+    {:halt, {state, events}}
+  end
+
+  defp handle_mint_response({:data, ref, chunk}, {%{ref: ref} = state, events}) do
     buffer = state.buffer <> chunk
     event_binaries = String.split(buffer, "\n\n")
     {event_binaries, [buffer]} = Enum.split(event_binaries, -1)
-    events = Enum.map(event_binaries, &Event.from_string/1)
 
-    unless events == [] do
-      Logger.info(fn -> "#{__MODULE__} sending #{length(events)} events" end)
+    new_events = Enum.map(event_binaries, &Event.from_string/1)
 
-      for event <- events do
+    unless new_events == [] do
+      Logger.info(fn -> "#{__MODULE__} sending #{length(new_events)} events" end)
+
+      for event <- new_events do
         Logger.debug(fn ->
           inspect(event, limit: :infinity, printable_limit: :infinity)
         end)
@@ -95,36 +156,20 @@ defmodule ServerSentEventStage do
     end
 
     state = %{state | buffer: buffer}
-    {:noreply, events, state}
+    {:cont, {state, events ++ new_events}}
   end
 
-  def handle_info(%HTTPoison.Error{id: id, reason: reason}, %{id: id} = state) do
-    Logger.error(fn -> "#{__MODULE__} HTTP error: #{inspect(reason)}" end)
-    state = reset_state(state)
-    send(self(), :connect)
-    {:noreply, [], state}
-  end
-
-  def handle_info(%HTTPoison.AsyncEnd{id: id}, %{id: id} = state) do
+  defp handle_mint_response({:done, ref}, {%{ref: ref} = state, events}) do
     Logger.info(fn -> "#{__MODULE__} disconnected, reconnecting..." end)
-    state = reset_state(state)
-    send(self(), :connect)
-    {:noreply, [], state}
+    state = do_refresh(state)
+    {:halt, {state, events}}
   end
 
-  def handle_info(%HTTPoison.AsyncRedirect{id: id, to: location}, %{id: id} = state) do
-    {:ok, id} = connect_to_url(location, state.headers)
-    state = reset_state(state)
-    {:noreply, [], %{state | id: id}}
-  end
+  defp handle_mint_response({:error, ref, reason}, {%{ref: ref} = state, events}) do
+    Logger.error(fn -> "#{__MODULE__} HTTP error: #{inspect(reason)}" end)
 
-  def handle_info(msg, state) do
-    # ignore data received unexpectedly
-    Logger.warn(fn ->
-      "#{__MODULE__} unexpected message: #{inspect(msg)}\nState: #{inspect(state)}"
-    end)
-
-    {:noreply, [], state}
+    state = do_refresh(state)
+    {:halt, {state, events}}
   end
 
   @doc false
@@ -139,31 +184,69 @@ defmodule ServerSentEventStage do
     {:noreply, [], state}
   end
 
+  defp do_connect(url, state) do
+    case connect_to_url(url, state.headers) do
+      {:ok, conn, ref} ->
+        %{state | conn: conn, ref: ref}
+
+      {:error, reason} ->
+        Logger.error(fn ->
+          "#{__MODULE__} unable to connect url=#{inspect(url)} reason=#{inspect(reason)}"
+        end)
+
+        do_refresh(state)
+    end
+  end
+
   defp connect_to_url(url, headers) do
     Logger.debug(fn -> "#{__MODULE__} requesting #{url}" end)
 
-    headers = [
-      {"Accept", "text/event-stream"} | headers
-    ]
+    uri = URI.parse(url)
 
-    {:ok, %{id: id}} =
-      HTTPoison.get(
-        url,
-        headers,
-        recv_timeout: 60_000,
-        follow_redirect: true,
-        stream_to: self()
-      )
+    scheme =
+      case uri.scheme do
+        "https" -> :https
+        "http" -> :http
+      end
 
-    {:ok, id}
+    case HTTP.connect(scheme, uri.host, uri.port, transport_opts: [timeout: 60_000]) do
+      {:ok, conn} ->
+        headers = [
+          {"Accept", "text/event-stream"} | headers
+        ]
+
+        path =
+          case {uri.path, uri.query} do
+            {nil, nil} ->
+              "/"
+
+            {path, nil} ->
+              path
+
+            {nil, query} ->
+              "/?" <> query
+
+            {path, query} ->
+              path <> "?" <> query
+          end
+
+        {:ok, conn, ref} = HTTP.request(conn, "GET", path, headers, nil)
+
+        {:ok, conn, ref}
+
+      {:error, _reason} = e ->
+        e
+
+      {:error, _conn, reason} ->
+        {:error, reason}
+    end
   end
 
-  defp maybe_connect(%{state: :not_connected}) do
-    send(self(), :connect)
-    :ok
-  end
+  defp maybe_connect(%{conn: conn}) do
+    if conn == nil or not HTTP.open?(conn, :read) do
+      send(self(), :connect)
+    end
 
-  defp maybe_connect(_state) do
     :ok
   end
 
@@ -176,14 +259,14 @@ defmodule ServerSentEventStage do
   end
 
   defp reset_state(state) do
-    %{state | id: nil, buffer: ""}
-  end
-
-  defp do_refresh(%{id: id} = state) do
-    unless is_nil(id) do
-      :hackney.close(id)
+    if state.conn != nil and HTTP.open?(state.conn, :read) do
+      {:ok, _conn} = HTTP.close(state.conn)
     end
 
+    %{state | conn: nil, ref: nil, redirecting?: false, buffer: ""}
+  end
+
+  defp do_refresh(state) do
     send(self(), :connect)
     reset_state(state)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,8 @@ defmodule ServerSentEventStage.MixProject do
   defp deps do
     [
       {:gen_stage, "~> 0.13"},
-      {:httpoison, "~> 1.1"},
+      {:mint, "~> 1.0"},
+      {:castore, "~> 0.1", optional: true},
       {:bypass, "~> 0.8", only: :test, optional: true},
       {:excoveralls, "~> 0.8", only: :test, optional: true},
       {:ex_doc, "~> 0.18", optional: true}

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
 %{
   "bypass": {:hex, :bypass, "0.8.1", "16d409e05530ece4a72fabcf021a3e5c7e15dcc77f911423196a0c551f2a15ca", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, repo: "hexpm", optional: false]}, {:plug, "~> 1.0", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
+  "castore": {:hex, :castore, "0.1.5", "591c763a637af2cc468a72f006878584bc6c306f8d111ef8ba1d4c10e0684010", [:mix], [], "hexpm"},
   "certifi": {:hex, :certifi, "2.3.1", "d0f424232390bf47d82da8478022301c561cf6445b5b5fb6a84d49a9e76d2639", [:rebar3], [{:parse_trans, "3.2.0", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
   "cowboy": {:hex, :cowboy, "1.1.2", "61ac29ea970389a88eca5a65601460162d370a70018afe6f949a29dca91f3bb0", [:rebar3], [{:cowlib, "~> 1.0.2", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.3.2", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], [], "hexpm"},
@@ -9,7 +10,6 @@
   "exjsx": {:hex, :exjsx, "4.0.0", "60548841e0212df401e38e63c0078ec57b33e7ea49b032c796ccad8cde794b5c", [:mix], [{:jsx, "~> 2.8.0", [hex: :jsx, repo: "hexpm", optional: false]}], "hexpm"},
   "gen_stage": {:hex, :gen_stage, "0.13.1", "edff5bca9cab22c5d03a834062515e6a1aeeb7665fb44eddae086252e39c4378", [:mix], [], "hexpm"},
   "hackney": {:hex, :hackney, "1.12.1", "8bf2d0e11e722e533903fe126e14d6e7e94d9b7983ced595b75f532e04b7fdc7", [:rebar3], [{:certifi, "2.3.1", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "5.1.1", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
-  "httpoison": {:hex, :httpoison, "1.1.1", "96ed7ab79f78a31081bb523eefec205fd2900a02cda6dbc2300e7a1226219566", [:mix], [{:hackney, "~> 1.8", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "5.1.1", "cbc3b2fa1645113267cc59c760bafa64b2ea0334635ef06dbac8801e42f7279c", [:rebar3], [{:unicode_util_compat, "0.3.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
   "jsx": {:hex, :jsx, "2.8.3", "a05252d381885240744d955fbe3cf810504eb2567164824e19303ea59eef62cf", [:mix, :rebar3], [], "hexpm"},
   "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
@@ -17,6 +17,7 @@
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
   "mime": {:hex, :mime, "1.2.0", "78adaa84832b3680de06f88f0997e3ead3b451a440d183d688085be2d709b534", [:mix], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], [], "hexpm"},
+  "mint": {:hex, :mint, "1.0.0", "ca5ab33497ba2bdcc42f6cdd3927420a6159116be87c8173658e93c8746703da", [:mix], [{:castore, "~> 0.1.0", [hex: :castore, repo: "hexpm", optional: true]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
   "oauther": {:hex, :oauther, "1.1.1", "7d8b16167bb587ecbcddd3f8792beb9ec3e7b65c1f8ebd86b8dd25318d535752", [:mix], [], "hexpm"},
   "parse_trans": {:hex, :parse_trans, "3.2.0", "2adfa4daf80c14dc36f522cf190eb5c4ee3e28008fc6394397c16f62a26258c2", [:rebar3], [], "hexpm"},


### PR DESCRIPTION
Since we don't need all the pooling features that HTTPoison & Hackney
provide, we can use the architecturally simpler Mint.

Mint is a "Small and composable HTTP client", which uses a connection struct
to maintain the state. As messages come into our GenStage server, we pass
them to Mint where they're parsed into responses.

The main change is to redirection, which we need to handle ourselves now.