### PR TITLE
BREAKING: bump the minimum supported Elixir version to 1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.0
 
 - Switch to Mint as our HTTP library. We optionally depend on `ca_store` for certificate validation.
+- Bump the minimum supported Elixir version to 1.7
 
 ## 0.4.1
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule ServerSentEventStage.MixProject do
     [
       app: :server_sent_event_stage,
       version: "1.0.0",
-      elixir: "~> 1.6 or ~> 1.7 or ~> 1.8 or ~> 1.9",
+      elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       name: "ServerSentEventStage",


### PR DESCRIPTION
I haven't released 1.0.0 yet, so this doesn't require another bump. When I updated the version of ExDoc, I didn't realize that it dropped support for Elixir 1.6. We don't have any applications using this which also need Elixir 1.6, so it's safe for us to bump the minimum supported version.

I also updated the CI configuration so that this issue with the documentation will be caught as a part of the tests.