### PR TITLE
fix: close connection before re-connecting 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.1
+
+- Fix a process leak when re-connecting to the remote server
+- Include the URL along with the log messages to distinguish multiple stages
+
 ## 1.0.0
 
 - Switch to Mint as our HTTP library. We optionally depend on `ca_store` for certificate validation.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ServerSentEventStage.MixProject do
   def project do
     [
       app: :server_sent_event_stage,
-      version: "1.0.0",
+      version: "1.0.1",
       elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
By moving the call to `reset_state/1` into `do_connect/2`, we ensure that
we're always closing the existing HTTP connection before creating a new one.