### PR TITLE
ci: add step to validate Hex.pm package build

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -70,4 +70,8 @@ jobs:
         with:
           name: elixir-lcov
           path: cover/
+      - name: Hex.pm build
+        run: |
+          mix hex.build
+          mix docs
       - uses: mbta/actions/dialyzer@v1


### PR DESCRIPTION
This was in SemaphoreCI, but not not originally replicated.