### PR TITLE
deps: allow `castore` 1.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A GenStage producer which parses the ServerSentEvent protocol.
 def deps do
   [
     {:server_sent_event_stage, "~> 1.0.0"},
-    {:castore, "~> 0.1"}
+    {:castore, "~> 1.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule ServerSentEventStage.MixProject do
     [
       {:gen_stage, "~> 1.1"},
       {:mint, "~> 1.4"},
-      {:castore, "~> 0.1", optional: true},
+      {:castore, "~> 0.1.0 or ~> 1.0", optional: true},
       {:bypass, "~> 2.1", only: :test, optional: true},
       {:lcov_ex, "~> 0.2", only: :test, optional: true},
       {:credo, "~> 1.6", only: :dev, optional: true},


### PR DESCRIPTION
CAStore 1.0 is a rename of 0.1 with [no substantive changes](https://diff.hex.pm/diff/castore/0.1.22..1.0.0). Loosening this version constraint allows apps that use this library to continue updating to newer versions of the certificate store without adding an override.