### PR TITLE
doc: explain OpenSSL configuration for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ children = [
 
 Full documentation is available on [HexDocs](https://hexdocs.pm/server_sent_event_stage/).
 
+## Development
+
+This project is developed against a version of Erlang that has trouble finding
+OpenSSL on some systems. You may see `* ssl : No usable OpenSSL found` in the
+Erlang compile output, and `mix deps.get` will subsequently fail due to missing
+SSL support. To fix this, compile Erlang using the `--with-ssl=<PATH>` option.
+For example, on macOS using OpenSSL installed through Homebrew:
+
+    KERL_CONFIGURE_OPTIONS="--with-ssl=$(brew --prefix openssl)" asdf install
+
 ## License
 
 `server_sent_event_stage` is licensed under the [MIT](LICENSE) license.


### PR DESCRIPTION
I had some trouble getting this project set up when working on #17, and thought it would be good to save future contributors the time it took me to track down the solution.

I don't think this is an issue on Erlang 25+, since I have installed a few versions of that so far on macOS 14 using OpenSSL 3 and haven't had to use this workaround.