### PR TITLE
chore: cut release 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.1
+
+- Allow version 1.x of the optional `ca_store` dependency, as there are no breaking changes from 0.1.x.
+
 ## 1.2.0
 
 - feat: optionally time out if stream goes idle (@boringcactus)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ServerSentEventStage.MixProject do
   def project do
     [
       app: :server_sent_event_stage,
-      version: "1.2.0",
+      version: "1.2.1",
       elixir: ">= 1.11.4 and < 2.0.0",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
Thought it would be nice to get this out, both to unblock `ca_store` upgrades and to align with the updated README, which now says to add `ca_store` with a constraint of `~> 1.0` (if you did this with the current published version, there would be a conflict).

@paulswartz if you approve, do you want to handle the publishing to Hex? I haven't done that before and I assume you're already set up for it.